### PR TITLE
Update for blobstore compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,29 @@ COPY ./ /kb/module
 RUN mkdir -p /kb/module/work
 RUN chmod -R 777 /kb/module
 
+RUN add-apt-repository ppa:openjdk-r/ppa \
+	&& sudo apt-get update \
+	&& sudo apt-get -y install openjdk-8-jdk \
+	&& echo java versions: \
+	&& java -version \
+	&& javac -version \
+	&& echo $JAVA_HOME \
+	&& ls -l /usr/lib/jvm \
+	&& cd /kb/runtime \
+	&& rm java \
+	&& ln -s /usr/lib/jvm/java-8-openjdk-amd64 java \
+	&& ls -l
+
+ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
+
 WORKDIR /kb/module
-RUN keytool -import -keystore /usr/lib/jvm/java-7-oracle/jre/lib/security/cacerts -storepass changeit -noprompt -trustcacerts -alias letsencryptauthorityx3 -file ./ssl/lets-encrypt-x3-cross-signed.der
+
+# get most up to date jars, note will be cached so change this RUN to update
+RUN cd /kb/dev_container/modules/jars \
+    && git pull \
+    && . /kb/dev_container/user-env.sh \
+    && make deploy \
+    && echo "this is only here to force an update: 1"
 
 RUN make all
 

--- a/build.xml
+++ b/build.xml
@@ -36,12 +36,12 @@
     <include name="syslog4j/syslog4j-0.9.46.jar"/>
     <include name="kbase/workspace/WorkspaceClient-0.6.0.jar"/>
     <include name="apache_commons/commons-io-2.4.jar"/>
-    <include name="kbase/shock/shock-client-0.0.15.jar"/>
+    <include name="kbase/shock/shock-client-0.1.0.jar"/>
     <include name="kbase/handle/HandleServiceClient-160803-b9de699.jar"/>
     <include name="kbase/genomes/kbase-genomes-20140411.jar"/>
-    <include name="apache_commons/http/httpclient-4.3.1.jar"/>
-    <include name="apache_commons/http/httpcore-4.3.jar"/>
-    <include name="apache_commons/http/httpmime-4.3.1.jar"/>
+    <include name="apache_commons/http/httpclient-4.5.2.jar"/>
+    <include name="apache_commons/http/httpcore-4.4.5.jar"/>
+    <include name="apache_commons/http/httpmime-4.5.8.jar"/>
     <include name="apache_commons/commons-lang3-3.1.jar"/>
     <include name="apache_commons/commons-logging-1.1.1.jar"/>
   </fileset>


### PR DESCRIPTION
New Shock client should be compatible with both Shock and the Blobstore

Tests pass locally